### PR TITLE
added keyframe stepping functionality to keys f and g, backwards and …

### DIFF
--- a/annotator/static/player.js
+++ b/annotator/static/player.js
@@ -176,6 +176,34 @@ class Player {
                 $(this).triggerHandler('change-keyframes');
             });
 
+            $(this.view).on('step-forward-keyframe', () => {
+                var time = this.view.video.currentTime;
+                for(var i = 0; i < this.selectedAnnotation.keyframes.length; i++) {
+                    var kf = this.selectedAnnotation.keyframes[i]
+                    if (time == kf.time) {
+                        if (i != this.selectedAnnotation.keyframes.length - 1) {
+                            var nf = this.selectedAnnotation.keyframes[i+1];
+                            this.view.video.currentTime = nf.time;
+                            break;
+                        }
+                    }
+                }
+            });
+
+            $(this.view).on('step-backward-keyframe', () => {
+                var time = this.view.video.currentTime;
+                for(var i = 0; i < this.selectedAnnotation.keyframes.length; i++) {
+                    var kf = this.selectedAnnotation.keyframes[i]
+                    if (time == kf.time) {
+                        if (i != 0) {
+                            var nf = this.selectedAnnotation.keyframes[i-1];
+                            this.view.video.currentTime = nf.time;
+                            break;
+                        }
+                    }
+                }
+            });
+
         });
     }
 

--- a/annotator/static/player.js
+++ b/annotator/static/player.js
@@ -178,11 +178,10 @@ class Player {
 
             $(this.view).on('step-forward-keyframe', () => {
                 var time = this.view.video.currentTime;
-                for(var i = 0; i < this.selectedAnnotation.keyframes.length; i++) {
-                    var kf = this.selectedAnnotation.keyframes[i]
+                for (let [i, kf] of this.selectedAnnotation.keyframes.entries()) {
                     if (time == kf.time) {
                         if (i != this.selectedAnnotation.keyframes.length - 1) {
-                            var nf = this.selectedAnnotation.keyframes[i+1];
+                            var nf = this.selectedAnnotation.keyframes[i + 1];
                             this.view.video.currentTime = nf.time;
                             break;
                         }
@@ -192,11 +191,10 @@ class Player {
 
             $(this.view).on('step-backward-keyframe', () => {
                 var time = this.view.video.currentTime;
-                for(var i = 0; i < this.selectedAnnotation.keyframes.length; i++) {
-                    var kf = this.selectedAnnotation.keyframes[i]
+                for (let [i, kf] of this.selectedAnnotation.keyframes.entries()) {
                     if (time == kf.time) {
-                        if (i != 0) {
-                            var nf = this.selectedAnnotation.keyframes[i-1];
+                        if (i !== 0) {
+                            var nf = this.selectedAnnotation.keyframes[i - 1];
                             this.view.video.currentTime = nf.time;
                             break;
                         }

--- a/annotator/static/views/player.js
+++ b/annotator/static/views/player.js
@@ -175,11 +175,21 @@ class PlayerView {
             $(this).on('keyup-period    keyup-e', () => this.pause());
             // Delete keyframe
             $(this).on('                keydn-d', () => this.deleteKeyframe());
+            // Keyframe stepping
+            $(this).on('keydn-g                ', () => this.stepforward());
+            $(this).on('keydn-f                ', () => this.stepbackward());
         });
     }
 
 
     // Time control
+    stepforward() {
+        $(this).trigger('step-forward-keyframe');
+    }
+
+    stepbackward() {
+        $(this).trigger('step-backward-keyframe');
+    }
 
     play() {
         if (this.video.currentTime < this.video.duration) {


### PR DESCRIPTION
added keyframe stepping functionality when in focus on a set of annotations. Pressing g will move the video to next keyframe in the set of selectedAnnotation and pressing f will move the video to the previous keyframe in the set of selectedAnnotation. Indexing is bounded so you can't go past or over.
