### PR TITLE
Stop interpolating flag

### DIFF
--- a/annotator/static/annotation.js
+++ b/annotator/static/annotation.js
@@ -118,6 +118,9 @@ class Annotation {
     updateKeyframe(frame, usePreciseFrameMatching)  {
         var {prevIndex, nextIndex, closestIndex} = this.getFrameAtTime(frame.time);
 
+        if (frame.continueInterpolation === undefined)
+            frame.continueInterpolation = true;
+
         // Update the closestIndex-th frame
         if (closestIndex != null) {
             this.keyframes[closestIndex] = frame;

--- a/annotator/static/annotation.js
+++ b/annotator/static/annotation.js
@@ -156,7 +156,8 @@ class Annotation {
         if (closestIndex == null && nextIndex != null) return false;
 
         // if we're the last frame - get or create a key frame just before this and mark it as continueInterpolation = false
-        if (nextIndex == null && time != 0) {
+        // if we've actually selected a frame rather than just an interpolation frame simply delete it (that's the closestIndex === null part)
+        if (nextIndex == null && time != 0 && closestIndex === null) {
             var justBeforeTime = usePreciseFrameMatching ? time - 1 : time - 2*this.SAME_FRAME_THRESHOLD;
             var newFrame = {
                                 time: justBeforeTime, 

--- a/annotator/static/annotation.js
+++ b/annotator/static/annotation.js
@@ -110,7 +110,7 @@ class Annotation {
             prevIndex: prevIndex,
             nextIndex: nextIndex,
             closestIndex: closestIndex,
-            continueInterpolation: this.keyframes[prevIndex].continueInterpolation,
+            continueInterpolation: prevIndex != null ? this.keyframes[prevIndex].continueInterpolation : true,
         };
     }
 

--- a/annotator/static/annotation.js
+++ b/annotator/static/annotation.js
@@ -154,7 +154,7 @@ class Annotation {
 
         // if we're the last frame - get or create a key frame just before this and mark it as continueInterpolation = false
         if (nextIndex == null && time != 0) {
-            var justBeforeTime = usePreciseFrameMatching ? time - 1 : time - 2*SAME_FRAME_THRESHOLD;
+            var justBeforeTime = usePreciseFrameMatching ? time - 1 : time - 2*this.SAME_FRAME_THRESHOLD;
             var newFrame = {
                                 time: justBeforeTime, 
                                 bounds: bounds,

--- a/annotator/static/app.js
+++ b/annotator/static/app.js
@@ -17,5 +17,6 @@ $(() => {
         videoId: window.video.id,
         videoStart: window.video.start_time,
         videoEnd: window.video.end_time,
+        isImageSequence: window.video.is_image_sequence,
     });
 });

--- a/annotator/static/datasources.js
+++ b/annotator/static/datasources.js
@@ -11,6 +11,7 @@ var DataSources = {
                     height: json.h,
                 }),
                 time: json.frame,
+                continueInterpolation: json.continueInterpolation === false ? false : true,
             };
         },
 
@@ -21,6 +22,7 @@ var DataSources = {
                 y: attr.y,
                 w: attr.width,
                 h: attr.height,
+                continueInterpolation: frame.continueInterpolation, 
                 frame: frame.time,
             };
         },

--- a/annotator/static/misc.js
+++ b/annotator/static/misc.js
@@ -228,6 +228,7 @@ var Misc = {
          38: "arrowup",
          39: "arrowright",
          40: "arrowdown",
+         46: "delete",
          48: "0",
          49: "1",
          50: "2",

--- a/annotator/static/player.js
+++ b/annotator/static/player.js
@@ -234,10 +234,14 @@ class Player {
         
         var {bounds, prevIndex, nextIndex, closestIndex, continueInterpolation} = annotation.getFrameAtTime(time, this.isImageSequence);
 
+        // singlekeyframe determines whether we show or hide the object
+        // we want to hide if:
+        //   - the very first frame object is in the future (nextIndex == 0 && closestIndex is null)
+        //   - we're after the last frame and that last frame was marked as continueInterpolation false
         rect.appear({
             real: closestIndex != null,
             selected: this.selectedAnnotation === annotation,
-            singlekeyframe: nextIndex != null || continueInterpolation
+            singlekeyframe: continueInterpolation && !(nextIndex == 0 && closestIndex === null)
         });
 
         // Don't mess up our drag

--- a/annotator/static/player.js
+++ b/annotator/static/player.js
@@ -180,11 +180,13 @@ class Player {
 
             $(this.view).on('step-forward-keyframe', () => {
                 var time = this.view.video.currentTime;
+                if (!this.selectedAnnotation || !this.selectedAnnotation.keyframes)
+                    return;
                 for (let [i, kf] of this.selectedAnnotation.keyframes.entries()) {
-                    if (time == kf.time) {
+                    if (Math.abs(time - kf.time) < this.selectedAnnotation.SAME_FRAME_THRESHOLD) {
                         if (i != this.selectedAnnotation.keyframes.length - 1) {
                             var nf = this.selectedAnnotation.keyframes[i + 1];
-                            this.view.video.currentTime = nf.time;
+                            this.view.video.setCurrentTime(nf.time);
                             break;
                         }
                     }
@@ -193,11 +195,14 @@ class Player {
 
             $(this.view).on('step-backward-keyframe', () => {
                 var time = this.view.video.currentTime;
+                var selected = this.selectedAnnotation;
+                if (!this.selectedAnnotation || !this.selectedAnnotation.keyframes)
+                    return;
                 for (let [i, kf] of this.selectedAnnotation.keyframes.entries()) {
-                    if (time == kf.time) {
+                    if (Math.abs(time - kf.time) < this.selectedAnnotation.SAME_FRAME_THRESHOLD) {
                         if (i !== 0) {
                             var nf = this.selectedAnnotation.keyframes[i - 1];
-                            this.view.video.currentTime = nf.time;
+                            this.view.video.setCurrentTime(nf.time);
                             break;
                         }
                     }

--- a/annotator/static/player.js
+++ b/annotator/static/player.js
@@ -2,7 +2,7 @@
 
 
 class Player {
-    constructor({$container, videoSrc, videoId, videoStart, videoEnd}) {
+    constructor({$container, videoSrc, videoId, videoStart, videoEnd, isImageSequence}) {
         this.$container = $container;
         
         this.videoId = videoId;
@@ -20,6 +20,8 @@ class Player {
         this.videoStart = videoStart;
 
         this.videoEnd = videoEnd;
+
+        this.isImageSequence = isImageSequence;
 
         this.metrics = {
             playerStartTimes: Date.now(),
@@ -90,7 +92,7 @@ class Player {
             annotation.updateKeyframe({
                 time: this.view.video.currentTime,
                 bounds: bounds,
-            });
+            }, this.isImageSequence);
             $(this).triggerHandler('change-onscreen-annotations');
             $(this).triggerHandler('change-keyframes');
         });
@@ -229,11 +231,13 @@ class Player {
             this.metrics.annotationsStartTime = Date.now();
         }
         var time = this.view.video.currentTime;
-        var {bounds, prevIndex, nextIndex, closestIndex} = annotation.getFrameAtTime(time);
+        
+        var {bounds, prevIndex, nextIndex, closestIndex, continueInterpolation} = annotation.getFrameAtTime(time, this.isImageSequence);
 
         rect.appear({
-            real: closestIndex != null || (prevIndex != null && nextIndex != null),
+            real: closestIndex != null,
             selected: this.selectedAnnotation === annotation,
+            singlekeyframe: nextIndex != null || continueInterpolation
         });
 
         // Don't mess up our drag
@@ -297,11 +301,11 @@ class Player {
     }
 
     addAnnotationAtCurrentTimeFromRect(rect) {
-        var annotation = Annotation.newFromCreationRect();
+        var annotation = Annotation.newFromCreationRect(this.isImageSequence);
         annotation.updateKeyframe({
             time: this.view.video.currentTime,
             bounds: rect.bounds
-        });
+        }, this.isImageSequence);
         this.annotations.push(annotation);
         rect.fill = annotation.fill;
         this.initBindAnnotationAndRect(annotation, rect);
@@ -328,11 +332,12 @@ class Player {
 
     deleteSelectedKeyframe() {
         if (this.selectedAnnotation == null) return false;
+        var selected = this.selectedAnnotation;
+        this.selectedAnnotation = null; 
+        selected.deleteKeyframeAtTime(this.view.video.currentTime, this.isImageSequence);
 
-        this.selectedAnnotation.deleteKeyframeAtTime(this.view.video.currentTime);
-
-        if (this.selectedAnnotation.keyframes.length === 0) {
-            this.deleteAnnotation(this.selectedAnnotation);
+        if (selected.keyframes.length === 0) {
+            this.deleteAnnotation(selected);
         }
 
         return true;

--- a/annotator/static/views/player.js
+++ b/annotator/static/views/player.js
@@ -196,7 +196,7 @@ class PlayerView {
             $(this).on('keydn-period    keydn-e', () => this.play());
             $(this).on('keyup-period    keyup-e', () => this.pause());
             // Delete keyframe
-            $(this).on('                keydn-d', () => this.deleteKeyframe());
+            $(this).on('keyup-delete    keyup-d', () => this.deleteKeyframe());
             // Keyframe stepping
             $(this).on('keydn-g                ', () => this.stepforward());
             $(this).on('keydn-f                ', () => this.stepbackward());

--- a/annotator/static/views/player.js
+++ b/annotator/static/views/player.js
@@ -12,7 +12,7 @@ var PlayerViewConstants = {
 
 
 class PlayerView {
-    constructor({$container, videoSrc, videoStart, videoEnd}) {
+    constructor({$container, videoSrc, videoStart, videoEnd, isImageSequence}) {
         // This container of the player
         this.$container = $container;
 
@@ -54,6 +54,9 @@ class PlayerView {
 
         // are we waiting for buffering
         this.loading = true;
+
+        // whether or not we are using an image sequence or a video style renderer
+        this.isImageSequence = isImageSequence;
 
         // Promises
         this.keyframebarReady = Misc.CustomPromise();

--- a/annotator/views.py
+++ b/annotator/views.py
@@ -51,7 +51,7 @@ def video(request, video_id):
         'id': video.id,
         'location': video.url,
         'path': video.host,
-        'is_video': not video.image_list,
+        'is_image_sequence': True if video.image_list else False,
         'annotated': video.annotation != '',
         'verified': video.verified,
         'start_time': start_time,


### PR DESCRIPTION
Hi,

This one is a bigger change that you may want to consider carefully accepting or not. We think it's an improvement but there is an impact.

We found cases where labelled boxes would disappear from the screen beyond a certain time in the video/image sequence. After investigation, they were disappearing because an additional parameter in player.js drawAnnotationOnRect -> rect.appear, singlekeyframe was not being passed and there were certain states with closestIndex, prevIndex and nextIndex that would cause boxes to disappear.

Our change allows the user to control when a box no longer appears in the scene. When you delete a box (with the delete key or 'd'), if it's the last in the annotation, it will add/update another box "just" before that frame and mark that box as "continueInterpolation:false", otherwise, a rect will interpolate through to the end of a video.

This may mean downstream behaviour needs to change with machine learning recipients of the output json.

Here's an example:

```
[
{
   "color": "#e5347b", 
   "keyframes": 
   [
      {"h": 22, "w": 25, "y": 92, "x": 594, "frame": 8.974208, "continueInterpolation": true}, 
      {"h": 22, "w": 25, "y": 87, "x": 581, "frame": 11.774208, "continueInterpolation": true}, 
      {"h": 22, "w": 25, "y": 72, "x": 561, "frame": 13.274208, "continueInterpolation": true}, 
      {"h": 33, "w": 35, "y": 58, "x": 532, "frame": 14.424208, "continueInterpolation": true}, 
      {"h": 81, "w": 91, "y": 282, "x": 378, "frame": 26.439178, "continueInterpolation": false}
   ], 
   "type":    "Car"
}
]
```