### PR TITLE
set control scrubber to blur whenever focused

### DIFF
--- a/annotator/static/views/player.js
+++ b/annotator/static/views/player.js
@@ -210,11 +210,12 @@ class PlayerView {
             // control-time <=> video
             this.$on('control-time', 'change', () => this.video.currentTime = this.controlTime);
             this.video.onTimeUpdate(() => this.controlTimeUnfocused = this.video.currentTime);
-            this.video.onPlaying(() => this.togglePlayPauseIcon())
-            this.video.onPause(() => this.togglePlayPauseIcon())
+            this.video.onPlaying(() => this.togglePlayPauseIcon());
+            this.video.onPause(() => this.togglePlayPauseIcon());
 
             // control-scrubber <=> video
             this.$on('control-scrubber', 'input', () => this.jumpToTimeAndPause(this.controlScrubber));
+            this.$('control-scrubber').on('focus', () => this.$('control-scrubber').blur());
             this.video.onTimeUpdate(() => this.controlScrubberInactive = this.video.currentTime);
 
             // keyframebar => video


### PR DESCRIPTION
Fixed by overriding the scrubber's input focus trigger to .blur() on default so that user is able to continue using the play/pause functionality bound to the spacebar after changing time with scrubber. Did not modify control-time (text input box for changing the time) because user might want to fine tune after changing the time.