### PR TITLE
Create Duplicate Frame Functionality

### DIFF
--- a/annotator/static/player.js
+++ b/annotator/static/player.js
@@ -216,6 +216,26 @@ class Player {
                 }
             });
 
+            $(this.view).on('duplicate-keyframe', () => {
+                var time = this.view.video.currentTime;
+
+                if (!this.selectedAnnotation || !this.selectedAnnotation.keyframes) {
+                    return;
+                }
+                var previousKeyFrame;
+                for (let [i, kf] of this.selectedAnnotation.keyframes.entries()) {
+                    if (Math.abs(kf.time - time) < this.selectedAnnotation.SAME_FRAME_THRESHOLD) {
+                        return;
+                    } else if (kf.time > time) {
+                        break;
+                    }
+                    previousKeyFrame = kf;
+                }
+                this.selectedAnnotation.updateKeyframe({time:time, bounds:previousKeyFrame.bounds}, this.isImageSequence);
+                $(this).triggerHandler('change-onscreen-annotations');
+                $(this).triggerHandler('change-keyframes');
+            });
+
         });
     }
 

--- a/annotator/static/views/player.js
+++ b/annotator/static/views/player.js
@@ -242,6 +242,8 @@ class PlayerView {
             // Keyframe stepping
             $(this).on('keydn-g                ', () => this.stepforward());
             $(this).on('keydn-f                ', () => this.stepbackward());
+            // Keyframe duplication
+            $(this).on('keydn-r                ', () => this.duplicateKeyFrame());
             // video frame stepping - capture the repeat events with the 'r' handler
             $(this).on('keydn-a keydnr-a     ', () => {
                 if (!this.loading)
@@ -428,6 +430,10 @@ class PlayerView {
             btnIcon.addClass('glyphicon-pause');
             btnIcon.removeClass('glyphicon-play');
         }
+    }
+
+    duplicateKeyFrame() {
+        $(this).trigger('duplicate-keyframe');
     }
 
 


### PR DESCRIPTION
Added code to create a duplicate frame if an annotation is selected. Frame will have the same bounds as the last frame as the last frame with a time less than the current time. A duplicate frame will not be created if the current time minus the previous frame time is less than SAME_FRAME_THRESHOLD.