### PR TITLE
added frame attribute functionality

### DIFF
--- a/annotator/static/annotation.js
+++ b/annotator/static/annotation.js
@@ -54,6 +54,7 @@ class Annotation {
             return {
                 time: time,
                 bounds: null,
+                attributes: null,
                 prevIndex: null,
                 nextIndex: null,
                 closestIndex: null,
@@ -107,6 +108,7 @@ class Annotation {
         return {
             time: time,
             bounds: bounds,
+            attributes: null,
             prevIndex: prevIndex,
             nextIndex: nextIndex,
             closestIndex: closestIndex,

--- a/annotator/static/datasources.js
+++ b/annotator/static/datasources.js
@@ -10,6 +10,7 @@ var DataSources = {
                     width: json.w,
                     height: json.h,
                 }),
+                attributes: json.attributes,
                 time: json.frame,
                 continueInterpolation: json.continueInterpolation === false ? false : true,
             };
@@ -24,6 +25,7 @@ var DataSources = {
                 h: attr.height,
                 continueInterpolation: frame.continueInterpolation, 
                 frame: frame.time,
+                attributes: frame.attributes,
             };
         },
     },

--- a/annotator/static/player.js
+++ b/annotator/static/player.js
@@ -137,6 +137,15 @@ class Player {
         // Drawing annotations
         $(this).on('change-onscreen-annotations', () => {
             this.drawOnscreenAnnotations();
+            if (this.selectedAnnotation) {
+                let index = this.selectedAnnotation.getFrameAtTime(this.view.video.currentTime).closestIndex;
+                let frame = this.selectedAnnotation.keyframes[index];
+                if (frame && frame.attributes) {
+                    $('#frame-attributes').val(frame.attributes);
+                } else {
+                    $('#frame-attributes').val("");
+                }
+            }
         });
 
         $(this).on('change-keyframes', () => {
@@ -234,6 +243,16 @@ class Player {
                 this.selectedAnnotation.updateKeyframe({time:time, bounds:previousKeyFrame.bounds}, this.isImageSequence);
                 $(this).triggerHandler('change-onscreen-annotations');
                 $(this).triggerHandler('change-keyframes');
+            });
+
+            $(this.view).on('change-frame-attributes', () => {
+                if (this.selectedAnnotation) {
+                    let frameAttributes = $('#frame-attributes');
+                    let newFrame = this.selectedAnnotation.getFrameAtTime(this.view.video.currentTime)
+                    newFrame.attributes = frameAttributes.val();
+                    this.selectedAnnotation.updateKeyframe(newFrame);
+                    frameAttributes.blur();
+                }
             });
 
         });

--- a/annotator/static/views/player.js
+++ b/annotator/static/views/player.js
@@ -270,6 +270,11 @@ class PlayerView {
                 this.video.fit();
                 this.sizeVideoFrame();
             });
+
+            $('#frame-attributes').on('change', () => {
+                $(this).triggerHandler('change-frame-attributes');
+            });
+
             this.sizeVideoFrame();
             this.loading = false;
         });

--- a/annotator/templates/video.html
+++ b/annotator/templates/video.html
@@ -125,6 +125,8 @@
         <div class="glyphicon glyphicon-trash player-control-delete-keyframe" title="Delete selected frame (shortcut - 'delete', 'd')"></div>
       </span>
       <input class="form-control player-control-time" id="frame-number" placeholder="0">
+      <label for="frame-attributes">Frame Attributes: </label>
+      <input id="frame-attributes" value="" style="color: black"/>
       <div class="pull-right">
         <input id="scale-checkbox" type="checkbox" />
         <label for="scale-checkbox">Scale to fit</label>


### PR DESCRIPTION
Added frame attribute functionality. Should only display the attributes of the frame when you click on a frame in the annotation. Even for video frames that have multiple frames within them, only the selected annotation's attribute should be displayed. Attribute box is cleared when the video starts playing again or basically whenever the time changes and the on screen annotations change.