### PR TITLE
Replacing quote with unquote call (Facing bug with that)

### DIFF
--- a/annotator/views.py
+++ b/annotator/views.py
@@ -158,7 +158,7 @@ def video(request, video_id):
         'label_data': label_data,
         'video_data': video_data,
         'image_list': list(map(urllib.parse.quote, json.loads(video.image_list))) if video.image_list else 0,
-        'image_list_path': urllib.parse.quote(video.host),
+        'image_list_path': urllib.parse.unquote(video.host),
         'help_url': settings.HELP_URL,
         'help_embed': settings.HELP_EMBED,
         'mturk_data': mturk_data,

--- a/annotator/views.py
+++ b/annotator/views.py
@@ -158,7 +158,7 @@ def video(request, video_id):
         'label_data': label_data,
         'video_data': video_data,
         'image_list': list(map(urllib.parse.quote, json.loads(video.image_list))) if video.image_list else 0,
-        'image_list_path': urllib.parse.unquote(video.host),
+        'image_list_path': urllib.parse.quote(video.host, safe='/:'),
         'help_url': settings.HELP_URL,
         'help_embed': settings.HELP_EMBED,
         'mturk_data': mturk_data,


### PR DESCRIPTION
I faced issue while I was adding a video with **image_list**. 
Following were my input to the page 
image_list = `["video_pilot/SEQ_6/630_L.jpg","video_pilot/SEQ_6/640_L.jpg","video_pilot/SEQ_6/650_L.jpg","video_pilot/SEQ_6/660_L.jpg"]`
host = `https://d197osy5kcs7h2.cloudfront.net/content`

After adding this video It was failing because all the generated URLs were wrong with following content

`https://demoserver.in/video/149/https%3A//d197osy5kcs7h2.cloudfront.net/content/video_pilot/SEQ_6/880_L.jpg`

The quote call was converting **https://** => **https%3A//** 
This after results in incorrect path.