### PR TITLE
Added support to export annotations

### DIFF
--- a/annotator/management/commands/export_annotations.py
+++ b/annotator/management/commands/export_annotations.py
@@ -81,7 +81,7 @@ the current timestamp.
 				obj[options['field']] = frames
 				print('--Created {} dense annotations for object {}'.format(len(frames), obj['id']))
 		
-		outpath = os.path.join(options['outdir'], str(video.id) + '.json')		
+		outpath = os.path.normpath(os.path.join(options['outdir'], str(video.id) + '.json'))
 		with open(outpath, 'w') as fh:
 			json.dump(content, fh, indent=4)
 		print('--Saved annotations to {}'.format(outpath))
@@ -93,20 +93,17 @@ the current timestamp.
 		if url == 'Image List':
 			return 1 # 1 FPS
 		else:
-			working_dir = os.getcwd()
-			if os.path.basename(working_dir) != 'BeaverDam':
-				print('Make the working directory BeaverDam root. Current working directory is'.format(working_dir))
-
-			if url.startswith('/static/'):
-				url = 'annotator' + url
+			ROOT = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+			if not url.startswith('http'):	
+				# Local file path, relative to serving directory			
+				url = os.path.normpath(os.path.join(ROOT, 'annotator', url.strip('/')))
 			
 			cmd = [
 				'ffprobe', 
 				'-print_format', 'json',
-				'-loglevel', 'fatal',
 				'-show_streams', 
 				'-count_frames',
-				'-select_streams', 'v'
+				'-select_streams', 'v:0'
 				'-i', url]        
 			p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)    
 			out, err =  p.communicate()

--- a/annotator/management/commands/export_annotations.py
+++ b/annotator/management/commands/export_annotations.py
@@ -99,18 +99,25 @@ the current timestamp.
 			return 1 # 1 FPS
 		else:
 			ROOT = os.path.join(os.path.dirname(__file__), '..', '..', '..')
-			if not url.startswith('http'):	
-				# Local file path, relative to serving directory			
-				url = os.path.normpath(os.path.join(ROOT, 'annotator', url.strip('/')))
 			
 			cmd = [
 				'ffprobe', 
+				'-hide_banner',				
 				'-print_format', 'json',
 				'-read_intervals', '%+{}'.format(probesecs),
 				'-show_streams', 
 				'-count_frames',
 				'-select_streams', 'v:0'
-				'-i', url]     
+			]
+			
+			if not url.startswith('http'):	
+				# Local file path, relative to serving directory			
+				url = os.path.normpath(os.path.join(ROOT, 'annotator', url.strip('/')))
+			else:
+				# Timeout for reaching remote file
+				cmd.extend(['-timeout', str(int(5e6))])
+			
+			cmd.extend(['-i', url])
 
 			try:   
 				p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)    

--- a/annotator/management/commands/export_annotations.py
+++ b/annotator/management/commands/export_annotations.py
@@ -40,6 +40,7 @@ the current timestamp.
 		parser.add_argument('--filter-ids', type=int, nargs='+', help='Only export these video ids.')		
 		parser.add_argument('--filter-verified', action='store_true', help='Only export verified annotations.')		
 		parser.add_argument('--sparse', action='store_true', help='Do not create dense annotations.')
+		parser.add_argument('--probe-seconds', type=int, help='Limit video probing to first n seconds of video.', default=2)
 
 	def handle(self, *args, **options):
 		os.makedirs(options['outdir'], exist_ok=True)
@@ -62,7 +63,7 @@ the current timestamp.
 		fps = options['fps']
 		if fps is None:
 			print('--Probing video {}'.format(video.id))
-			fps = self.probe_video(video)
+			fps = self.probe_video(video, probesecs=options['probe_seconds'])
 			if fps is None:
 				print('--Failed to probe.')
 				return
@@ -86,7 +87,7 @@ the current timestamp.
 			json.dump(content, fh, indent=4)
 		print('--Saved annotations to {}'.format(outpath))
 
-	def probe_video(self, video):
+	def probe_video(self, video, probesecs):
 		'''Probe video file or image directory for FPS and number of frames.'''
 		url = video.url
 
@@ -101,6 +102,7 @@ the current timestamp.
 			cmd = [
 				'ffprobe', 
 				'-print_format', 'json',
+				'-read_intervals', '%+{}'.format(probesecs),
 				'-show_streams', 
 				'-count_frames',
 				'-select_streams', 'v:0'

--- a/annotator/management/commands/export_annotations.py
+++ b/annotator/management/commands/export_annotations.py
@@ -34,7 +34,7 @@ the current timestamp.
 
 	def add_arguments(self, parser):	
 		parser.add_argument('--fps', type=float, help='Number of frames / second. If omitted, video will be probed for fps.')
-		parser.add_argument('--outdir', help='Output directory', default='./exported_annotations')
+		parser.add_argument('--out-dir', help='Output directory', default='./exported_annotations')
 		parser.add_argument('--field', help='JSON field name to hold dense annotations', default='frames')
 		parser.add_argument('--eps', type=float, help='Approximate key frame matching threshold. If omitted will computed based on fps.')
 		parser.add_argument('--filter-ids', type=int, nargs='+', help='Only export these video ids.')		
@@ -43,7 +43,7 @@ the current timestamp.
 		parser.add_argument('--probe-seconds', type=int, help='Limit video probing to first n seconds of video.', default=2)
 
 	def handle(self, *args, **options):
-		os.makedirs(options['outdir'], exist_ok=True)
+		os.makedirs(options['out_dir'], exist_ok=True)
 
 		# Filter videos
 		filter_set = Video.objects.filter(annotation__gt='')
@@ -82,7 +82,7 @@ the current timestamp.
 				obj[options['field']] = frames
 				print('--Created {} dense annotations for object {}'.format(len(frames), obj['id']))
 		
-		outpath = os.path.normpath(os.path.join(options['outdir'], str(video.id) + '.json'))
+		outpath = os.path.normpath(os.path.join(options['out_dir'], str(video.id) + '.json'))
 		with open(outpath, 'w') as fh:
 			json.dump(content, fh, indent=4)
 		print('--Saved annotations to {}'.format(outpath))

--- a/annotator/management/commands/export_annotations.py
+++ b/annotator/management/commands/export_annotations.py
@@ -35,6 +35,7 @@ the current timestamp.
 	def add_arguments(self, parser):	
 		parser.add_argument('--fps', type=float, help='Number of frames / second. If omitted, video will be probed for fps.')
 		parser.add_argument('--out-dir', help='Output directory', default='./exported_annotations')
+		parser.add_argument('--out-use-filename', action='store_true', help='Use filename property instead of video id when exporting.')
 		parser.add_argument('--field', help='JSON field name to hold dense annotations', default='frames')
 		parser.add_argument('--eps', type=float, help='Approximate key frame matching threshold. If omitted will computed based on fps.')
 		parser.add_argument('--filter-ids', type=int, nargs='+', help='Only export these video ids.')		
@@ -82,7 +83,10 @@ the current timestamp.
 				obj[options['field']] = frames
 				print('--Created {} dense annotations for object {}'.format(len(frames), obj['id']))
 		
-		outpath = os.path.normpath(os.path.join(options['out_dir'], str(video.id) + '.json'))
+		filename = str(video.id) + '.json'
+		if options['out_use_filename'] and len(video.filename) > 0:
+			filename = str(video.filename) + '.json'
+		outpath = os.path.normpath(os.path.join(options['out_dir'], filename))
 		with open(outpath, 'w') as fh:
 			json.dump(content, fh, indent=4)
 		print('--Saved annotations to {}'.format(outpath))

--- a/annotator/management/commands/export_annotations.py
+++ b/annotator/management/commands/export_annotations.py
@@ -1,0 +1,197 @@
+from django.core.management.base import BaseCommand, CommandError
+from annotator.models import Video
+import os
+import json
+import re
+import os
+import shutil
+import subprocess
+import math
+
+
+class Command(BaseCommand):
+	help = r'''Exports video annotations
+
+This command creates JSON annotation files from video annotations. Besides keyframe annotations
+this script also creates dense annotations, i.e interpolates between keyframes. To do so, the 
+FPS of the video is required, which can be deduced automatically by video probing (requires ffmpeg).
+
+	python manage.py export_annotations
+
+Will create JSON annotation files for each video that has annotations. Use `--filter-` arguments
+to limit the number of matching video files. For example
+
+	python manage.py export_annotations --filter-ids 1 5 --filter-verified 
+
+would limit export to videos 1 and 5 if they are verified. 
+
+A note on dense annotations: Dense annotations will be created between the first and last keyframe.
+Between keyframes linear interpolation is used to advance bounding rectangle information. State 
+information is always copied from the earlier of two keyframes involved in interpolation. 
+Interpolation will be replaced by a direct keyframe copy if the keyframe timestamp is within `eps` of
+the current timestamp.
+'''
+
+	def add_arguments(self, parser):	
+		parser.add_argument('--fps', type=float, help='Number of frames / second. If omitted, video will be probed for fps.')
+		parser.add_argument('--outdir', help='Output directory', default='./exported_annotations')
+		parser.add_argument('--field', help='JSON field name to hold dense annotations', default='frames')
+		parser.add_argument('--eps', type=float, help='Approximate key frame matching threshold. If omitted will computed based on fps.')
+		parser.add_argument('--filter-ids', type=int, nargs='+', help='Only export these video ids.')		
+		parser.add_argument('--filter-verified', action='store_true', help='Only export verified annotations.')		
+		parser.add_argument('--sparse', action='store_true', help='Do not create dense annotations.')
+
+	def handle(self, *args, **options):
+		os.makedirs(options['outdir'], exist_ok=True)
+
+		# Filter videos
+		filter_set = Video.objects.filter(annotation__gt='')
+		if options['filter_ids']:
+			filter_set &= Video.objects.filter(id__in=options['filter_ids'])
+		if options['filter_verified']:
+			filter_set &= Video.objects.filter(verified=True)
+
+		print('Found {} videos matching filter query'.format(len(filter_set)))
+
+		for vid in filter_set:
+			print('Processing video {}'.format(vid))
+			self.export_annotations(vid, options)
+
+	def export_annotations(self, video, options):		
+		
+		fps = options['fps']
+		if fps is None:
+			print('--Probing video {}'.format(video.id))
+			fps = self.probe_video(video)
+			if fps is None:
+				print('--Failed to probe.')
+				return
+			print('--Estimated fps {:.2f}'.format(fps))
+
+		eps = options['eps']
+		if eps is None:
+			eps = (1 / fps) * 0.5
+			print('--Computing eps as {:.2f}'.format(eps))
+
+		content = json.loads(video.annotation)
+
+		if not options['sparse']:
+			for obj in content:				
+				frames = self.create_dense_annotations(obj, eps, fps)
+				obj[options['field']] = frames
+				print('--Created {} dense annotations for object {}'.format(len(frames), obj['id']))
+		
+		outpath = os.path.join(options['outdir'], str(video.id) + '.json')		
+		with open(outpath, 'w') as fh:
+			json.dump(content, fh, indent=4)
+		print('--Saved annotations to {}'.format(outpath))
+
+	def probe_video(self, video):
+		'''Probe video file or image directory for FPS and number of frames.'''
+		url = video.url
+
+		if url == 'Image List':
+			return 1 # 1 FPS
+		else:
+			working_dir = os.getcwd()
+			if os.path.basename(working_dir) != 'BeaverDam':
+				print('Make the working directory BeaverDam root. Current working directory is'.format(working_dir))
+
+			if url.startswith('/static/'):
+				url = 'annotator' + url
+			
+			cmd = [
+				'ffprobe', 
+				'-print_format', 'json',
+				'-loglevel', 'fatal',
+				'-show_streams', 
+				'-count_frames',
+				'-select_streams', 'v'
+				'-i', url]        
+			p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)    
+			out, err =  p.communicate()
+			if p.returncode != 0:
+				print('--Failed to probe video with error {}'.format(err))
+				return None
+			
+			content = json.loads(out.decode('utf-8'))
+			stream = content['streams'][0]
+			return eval(stream['r_frame_rate'])
+
+	def create_dense_annotations(self, obj, eps, fps):
+		'''Creates dense annotations for a BeaverDam JSON object.
+		
+		Dense annotations will be created between the first and last keyframe.
+		Between keyframes linear interpolation is used to advance bounding rectangle
+		information. State information is always copied from the earlier of two
+		keyframes involved in interpolation. Interpolation will be replaced by a
+		direct keyframe copy if the keyframe timestamp is within `eps` of
+		the current timestamp.
+		
+		The following information is stored within generated annotations:
+			- `frameid` : Zero based frame index.
+			- `frame`: timestamp of current frame, computed as `framerate * frameid`.
+			- `state`: State set during labeling. See BeaverDam documentation.
+			- `x,y,w,h`: Bounds information.
+			- `refid`: Keyframe reference index if direct keyframe copy is applied.
+		'''
+
+		keyframes = sorted(obj['keyframes'], key=lambda x: x['frame'])
+			
+		newframes = []
+		if len(keyframes) == 0:
+			return newframes
+
+		framerate = 1. / fps
+		fidx = int(math.floor(keyframes[0]['frame'] / framerate))
+		knext = 0
+		
+		while knext < len(keyframes):        
+
+			tnext = keyframes[knext]['frame']
+			t = fidx * framerate
+			td = tnext - t
+			
+			isinrange = abs(td) <= eps
+
+			if isinrange:
+				frame = dict(keyframes[knext])
+				frame['frame'] = t
+				frame['frameid'] = fidx    
+				frame['refid'] = knext   
+				newframes.append(frame)
+			elif knext > 0:
+				kprev = knext - 1
+				frac = (t - keyframes[kprev]['frame']) / (tnext - keyframes[kprev]['frame'])
+				closer = kprev if frac <= 0.5 else knext
+				b = self.interpolate(
+					self.bounds_from_json(keyframes[kprev]), 
+					self.bounds_from_json(keyframes[knext]), 
+					frac)
+
+				frame = dict(keyframes[closer])
+				frame['frame'] = t
+				frame['state'] = keyframes[kprev]['state']
+				frame['frameid'] = fidx
+				frame.update(self.bounds_to_json(b))
+				newframes.append(frame)
+
+			if t + framerate > tnext:
+				knext += 1
+
+			fidx += 1
+
+		return newframes
+
+	def bounds_from_json(self, e):
+		'''Reads bounds from BeaverDam JSON.'''
+		return [e['x'], e['x'] + e['w'], e['y'], e['y'] + e['h']]
+
+	def bounds_to_json(self, b):
+		'''Converts array format to BeaverDam JSON.'''
+		return {'x' : b[0], 'y' : b[2], 'w' : b[1] - b[0], 'h' : b[3] - b[2]}
+
+	def interpolate(self, src, dst, frac):
+		'''Linear interpolation of rectangles.'''
+		ifrac = 1.0 - frac
+		return [s*ifrac + d*frac for s,d in zip(src, dst)]


### PR DESCRIPTION
The backend command supports sparse / dense annotations (as requested in #132) as and writes results in standard BeaverDam JSON format. Dense annotations are created between first and last keyframe using interpolation. Since BeaverDam uses html5 currentTime as timestamping mechanism, the command will need to know the fps of the video files. If not specified via command line, video files will automatically be probed using ffmpeg. This command should support local, remote video files and image lists.

Type `python manage.py export_annotations --help` for usage help.

A simple annotation viewer using OpenCV can be found here
https://gist.github.com/cheind/9850e35bb08cfe12500942fb8b55531f

Dense annotations will be stored in a new JSON field ('frames' per default) that follows this structure
```python
{
    "frameid": 854,                     # Frame number with respect to start of video
    "frame": 68.32000000000001,         # Time measured in seconds from start computed as frameid * 1/FPS
    "state": "Red",                     # State copied from previous keyframe, or matching keyframe if refid is set
    "x": 1647.905947318195,             # interpolated x coordinate of bounds
    "y": 1142.1628561977332,            # interpolated y coordinate of bounds
    "w": 440.75167657459997,            # interpolated width of bounds
    "h": 451.9810186529337,             # interpolated height of bounds
    "continueInterpolation": true,      # -
    "refid": 17                         # Matched keyframe ID if any
}
```

Note that BeaverDam uses HTML5 `currentTime` to store keyframe times. These times vary between browsers and some browsers might even reduce the resolution of this field on purpose.  See

https://stackoverflow.com/questions/32318333/html-5-currenttime-accuracy
https://bugs.chromium.org/p/chromium/issues/detail?id=555376

Therefore, the video probed FPS and hence computed frame times might not exactly match up the timestamps stored during browser annotation (except for image-lists where FPS is set to exactly 1).